### PR TITLE
Graceful errors.

### DIFF
--- a/src/custom_exception.py
+++ b/src/custom_exception.py
@@ -3,3 +3,7 @@
 class NeedUserInteraction(Exception):
     def __init__(self, message):
         super(Exception, self).__init__(message)
+
+class UnknownError(Exception):
+    def __init__(self, message):
+        super(Exception, self).__init__(message)

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -3,6 +3,7 @@
 import locale
 import time
 
+
 class I18n(object):
 
     @staticmethod
@@ -38,6 +39,8 @@ class I18n(object):
 
             'websocket.closed': 'Websocket closed.',
             'websocket.opened': 'Websocket opened.',
+            'failed_collect_websocket': 'Failed to collect a websocket from PixelCanvas.',
+            'failed_connect_websocket': 'Failed to connect to the websocket.',
 
             'strategy.left_right_top_bottom': 'Drawing from left to right, from top to bottom.',
             'strategy.right_left_top_bottom': 'Drawing from right to left, from top to bottom.',
@@ -118,6 +121,8 @@ class I18n(object):
 
             'websocket.closed': 'Websocket s\'est fermé.',
             'websocket.opened': 'Websocket s\'est ouvert.',
+            'failed_collect_websocket': 'Failed to collect a webhook from PixelCanvas. [NEEDS TRANSLATION]',
+            'failed_connect_websocket': 'Failed to connect to the websocket. [NEEDS TRANSLATION]',
 
             'strategy.left_right_top_bottom': 'Je dessine de gauche à droite, de haut en bas.',
             'strategy.right_left_top_bottom': 'Je dessine de droite à gauche, de haut en bas.',
@@ -199,6 +204,8 @@ class I18n(object):
 
             'websocket.closed': 'Websocket fechado',
             'websocket.opened': 'Websocket aberto',
+            'failed_collect_websocket': 'Failed to collect a webhook from PixelCanvas. [NEEDS TRANSLATION]',
+            'failed_connect_websocket': 'Failed to connect to the websocket. [NEEDS TRANSLATION]',
 
             'strategy.left_right_top_bottom': 'Desenha da esquerda para a direita, de cima para baixo',
             'strategy.right_left_top_bottom': 'Desenha da direita para a esquerda, de cima para baixo',

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -39,8 +39,8 @@ class I18n(object):
 
             'websocket.closed': 'Websocket closed.',
             'websocket.opened': 'Websocket opened.',
-            'failed_collect_websocket': 'Failed to collect a websocket from PixelCanvas.',
-            'failed_connect_websocket': 'Failed to connect to the websocket.',
+            'websocket.failed_collect': 'Failed to collect a websocket from PixelCanvas.',
+            'websocket.failed_connect': 'Failed to connect to the websocket.',
 
             'strategy.left_right_top_bottom': 'Drawing from left to right, from top to bottom.',
             'strategy.right_left_top_bottom': 'Drawing from right to left, from top to bottom.',
@@ -121,8 +121,8 @@ class I18n(object):
 
             'websocket.closed': 'Websocket s\'est fermé.',
             'websocket.opened': 'Websocket s\'est ouvert.',
-            'failed_collect_websocket': 'Failed to collect a webhook from PixelCanvas. [NEEDS TRANSLATION]',
-            'failed_connect_websocket': 'Failed to connect to the websocket. [NEEDS TRANSLATION]',
+            'websocket.failed_collect': 'Failed to collect a webhook from PixelCanvas. [NEEDS TRANSLATION]',
+            'websocket.failed_connect': 'Failed to connect to the websocket. [NEEDS TRANSLATION]',
 
             'strategy.left_right_top_bottom': 'Je dessine de gauche à droite, de haut en bas.',
             'strategy.right_left_top_bottom': 'Je dessine de droite à gauche, de haut en bas.',
@@ -204,8 +204,8 @@ class I18n(object):
 
             'websocket.closed': 'Websocket fechado',
             'websocket.opened': 'Websocket aberto',
-            'failed_collect_websocket': 'Failed to collect a webhook from PixelCanvas. [NEEDS TRANSLATION]',
-            'failed_connect_websocket': 'Failed to connect to the websocket. [NEEDS TRANSLATION]',
+            'websocket.failed_collect': 'Failed to collect a webhook from PixelCanvas. [NEEDS TRANSLATION]',
+            'websocket.failed_connect': 'Failed to connect to the websocket. [NEEDS TRANSLATION]',
 
             'strategy.left_right_top_bottom': 'Desenha da esquerda para a direita, de cima para baixo',
             'strategy.right_left_top_bottom': 'Desenha da direita para a esquerda, de cima para baixo',

--- a/src/pixelcanvasio.py
+++ b/src/pixelcanvasio.py
@@ -106,11 +106,11 @@ class PixelCanvasIO(object):
         x = bytearray(self.get(PixelCanvasIO.URL + 'api/bigchunk/%s.%s.bmp' % (center_x, center_y), stream=True).content)
         return x
 
-    @retry(json.decoder.JSONDecodeError, log_on_failure=I18n.get('failed_collect_websocket'), fatal=True)
+    @retry(json.decoder.JSONDecodeError, log_on_failure=I18n.get('websocket.failed_collect'), fatal=True)
     def get_ws(self):
         return self.get(PixelCanvasIO.URL + 'api/ws').json()['url']
 
-    @retry(Exception, log_on_failure=I18n.get('failed_connect_websocket'), fatal=True)
+    @retry(Exception, log_on_failure=I18n.get('websocket.failed_connect'), fatal=True)
     def connect_websocket(self, canvas, axis={'start_x': 0, 'end_x': 0, 'start_y': 0, 'end_y': 0},
                           print_all_websocket_log=False):
         def on_message(ws, message):

--- a/src/pixelcanvasio.py
+++ b/src/pixelcanvasio.py
@@ -59,7 +59,7 @@ class PixelCanvasIO(object):
         self.cookies = response.cookies
         return response.json()
 
-    @retry(UnknownError)
+    @retry(KeyError, UnknownError)
     def send_pixel(self, x, y, color):
         payload = {
             'x': x,
@@ -94,7 +94,11 @@ class PixelCanvasIO(object):
             return {'success': 0, 'waitSeconds': 5}
 
         try:
-            return response.json()
+            response_dict = response.json()
+            if 'waitSeconds' in response_dict:
+                return response_dict
+            else:
+                raise KeyError("No wait time specified by the server.")
         except Exception:
             raise UnknownError(str(response.text) + '-' + str(response.status_code))
 

--- a/src/pixelcanvasio.py
+++ b/src/pixelcanvasio.py
@@ -59,7 +59,7 @@ class PixelCanvasIO(object):
         self.cookies = response.cookies
         return response.json()
 
-    @retry(KeyError, UnknownError)
+    @retry((KeyError, UnknownError))
     def send_pixel(self, x, y, color):
         payload = {
             'x': x,

--- a/src/safetynet.py
+++ b/src/safetynet.py
@@ -1,0 +1,35 @@
+import logging
+import sys
+import time
+from functools import wraps
+
+logger = logging.getLogger('bot')
+
+
+def retry(exceptions, max_tries=4, delay=5, backoff=1.5, log_on_failure=None, fatal=False):
+    def deco_retry(func):
+        @wraps(func)
+        def func_retry(*args, **kwargs):
+            tries, current_delay = 0, delay
+            while tries < max_tries:
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:
+                    tries += 1
+                    logger.error(
+                        "Retried {0.__name__} for time {1}/{2}. "
+                        "{3.__class__.__name__}: {3}".format(func, tries, max_tries, e))
+                    current_delay *= backoff
+                    time.sleep(current_delay)
+
+            if log_on_failure:
+                logger.error(log_on_failure)
+            else:
+                logger.error(
+                    "{0.__name__} failed {1} time(s).".format(func, tries))
+            if fatal:
+                sys.exit()
+            else:
+                return func(*args, **kwargs)
+        return func_retry
+    return deco_retry

--- a/src/safetynet.py
+++ b/src/safetynet.py
@@ -20,7 +20,10 @@ def retry(exceptions, max_tries=4, delay=5, backoff=1.5, log_on_failure=None, fa
                         "Retried {0.__name__} for time {1}/{2}. "
                         "{3.__class__.__name__}: {3}".format(func, tries, max_tries, e))
                     current_delay *= backoff
-                    time.sleep(current_delay)
+                    if time < max_tries:
+                        # Only delay when we're going to try again, otherwise
+                        # we're just holding it up.
+                        time.sleep(current_delay)
 
             if log_on_failure:
                 logger.error(log_on_failure)

--- a/src/safetynet.py
+++ b/src/safetynet.py
@@ -20,7 +20,7 @@ def retry(exceptions, max_tries=4, delay=5, backoff=1.5, log_on_failure=None, fa
                         "Retried {0.__name__} for time {1}/{2}. "
                         "{3.__class__.__name__}: {3}".format(func, tries, max_tries, e))
                     current_delay *= backoff
-                    if time < max_tries:
+                    if tries < max_tries:
                         # Only delay when we're going to try again, otherwise
                         # we're just holding it up.
                         time.sleep(current_delay)


### PR DESCRIPTION
I've implemented a bare retry decorator, solely in `pixelcanvasio.py`, that should help us reduce some bugs we get.

I had to also create a new custom exception and apply that in `send_pixel` to avoid the decorator catching `NeedUserInteraction`, which we need to keep so that the user can input y/n for placing a pixel.

Others will need to implement this elsewhere, or guide me where to do so, because I am not sure where you'd specifically like errors to be handled and how to handle them.

Reference #49. 