### PR TITLE
Advanced logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Using this flag will cause the bot to ignore the -i tag, and output a QR code in
 
 * [optional] **-py** or **--point_y** is the y coordinate (relative to the canvas) you wish the spiral or radiate strategy to start from on your template.
 
+* [optional] **-v** or **--verbose** is a flag to show debugging prints in the terminal. By default they are sent only to the log file.
+
 #### Note:
 
 The reverse parameters only work on the linear draw strategies (linear and quickfill). Use to choose which corner to draw linearly from (default is top left corner).

--- a/main.py
+++ b/main.py
@@ -75,6 +75,9 @@ def parse_args():
                         dest='notify', action='store_true', help=I18n.get('--notify'))
     parser.add_argument('-o', '--output_file', required=False, default='logfile.log',
                         dest='log_file', help=I18n.get('--output_file'))
+    parser.add_argument('-v', '--verbose', required=False, default=False,
+                        dest='verbose', action='store_true',
+                        help=I18n.get('--verbose'))
 
     return parser.parse_args()
 
@@ -93,7 +96,7 @@ def setup_proxy(proxy_url, proxy_auth):
 
 def alert(message=''):
     # \a is ASCII Bell, it makes noise if the terminal supports it
-    print(('\a' * 5))
+    print(('\a' * 5), end='', flush=True)
     logger.info(message)
 
 
@@ -130,7 +133,7 @@ def main():
                                          + '[%(asctime)s] %(message)s',
                                          '%H:%M:%S')
     streamhandler = logging.StreamHandler(sys.stdout)
-    if False:  # TODO: verbose flag
+    if args.verbose:
         streamhandler.setLevel(logging.DEBUG)
     else:
         streamhandler.setLevel(logging.INFO)

--- a/main.py
+++ b/main.py
@@ -30,51 +30,51 @@ class FileFilter(logging.Filter):
 def parse_args():
     parser = ArgumentParser()
     parser.add_argument('-i', '--image', required=True, dest='file',
-                        help=I18n.get('--image', True))
+                        help=I18n.get('--image'))
     parser.add_argument('-f', '--fingerprint', required=True, dest='fingerprint',
-                        help=I18n.get('--fingerprint', True))
+                        help=I18n.get('--fingerprint'))
     parser.add_argument('-x', '--start_x', required=True, type=int, dest='start_x',
-                        help=I18n.get('--start_x', True))
+                        help=I18n.get('--start_x'))
     parser.add_argument('-y', '--start_y', required=True, type=int, dest='start_y',
-                        help=I18n.get('--start_y', True))
+                        help=I18n.get('--start_y'))
     parser.add_argument('-ci', '--colors_ignored', required=False, type=int, default=[], nargs='+', dest='colors_ignored',
-                        help=I18n.get('--colors_ignored', True))
+                        help=I18n.get('--colors_ignored'))
     parser.add_argument('-cno', '--colors_not_overwrite', required=False, type=int, default=[], nargs='+', dest='colors_not_overwrite',
-                        help=I18n.get('--colors_not_overwrite', True))
+                        help=I18n.get('--colors_not_overwrite'))
     parser.add_argument('-ds', '--draw_strategy', required=False, default='spiral', dest='draw_strategy',
-                        help=I18n.get('--draw_strategy', True))
+                        help=I18n.get('--draw_strategy'))
     parser.add_argument('--mode_defensive', required=False, default=True, dest='mode_defensive',
-                        help=I18n.get('--mode_defensive', True))
+                        help=I18n.get('--mode_defensive'))
     parser.add_argument('--proxy_url', required=False, dest='proxy_url',
-                        help=I18n.get('--proxy_url', True))
+                        help=I18n.get('--proxy_url'))
     parser.add_argument('--proxy_auth', required=False, dest='proxy_auth',
-                        help=I18n.get('--proxy_auth', True))
+                        help=I18n.get('--proxy_auth'))
     parser.add_argument('--round_sensitive', required=False, type=int, default=3, dest='round_sensitive',
-                        help=I18n.get('--round_sensitive', True))
+                        help=I18n.get('--round_sensitive'))
     parser.add_argument('--image_brightness', required=False, type=int, default=15, dest='image_brightness',
-                        help=I18n.get('--image_brightness', True))
+                        help=I18n.get('--image_brightness'))
     parser.add_argument('--detect_area_min_range', required=False, type=int, default=-5000, dest='min_range',
-                        help=I18n.get('--detect_area_min_range', True))
+                        help=I18n.get('--detect_area_min_range'))
     parser.add_argument('--detect_area_max_range', required=False, type=int, default=5000, dest='max_range',
-                        help=I18n.get('--detect_area_max_range', True))
+                        help=I18n.get('--detect_area_max_range'))
     parser.add_argument('--QR_text', required=False, default="", dest='QR_text',
-                        help=I18n.get('--QR_text', True))
+                        help=I18n.get('--QR_text'))
     parser.add_argument('--QR_scale', required=False, type=int, default=3, dest='QR_scale',
-                        help=I18n.get('--QR_scale', True))
+                        help=I18n.get('--QR_scale'))
     parser.add_argument('--xreversed', required=False, default=False, dest='xreversed',
-                        help=I18n.get('--xreversed', True))
+                        help=I18n.get('--xreversed'))
     parser.add_argument('--yreversed', required=False, default=False, dest='yreversed',
-                        help=I18n.get('--yreversed', True))
+                        help=I18n.get('--yreversed'))
     parser.add_argument('-px', '--point_x', required=False, type=int, default=None, dest='point_x',
-                        help=I18n.get('--point_x', True))
+                        help=I18n.get('--point_x'))
     parser.add_argument('-py', '--point_y', required=False, type=int, default=None, dest='point_y',
-                        help=I18n.get('--point_y', True))
+                        help=I18n.get('--point_y'))
     parser.add_argument('-p', '--prioritized', required=False, default=False, dest='prioritized',
-                        help=I18n.get('--yreversed', True))
+                        help=I18n.get('--yreversed'))
     parser.add_argument('-n', '--notify', required=False, default=False,
-                        dest='notify', action='store_true', help=I18n.get('--notify', True))
+                        dest='notify', action='store_true', help=I18n.get('--notify'))
     parser.add_argument('-o', '--output_file', required=False, default='logfile.log',
-                        dest='log_file', help=I18n.get('--output_file', True))
+                        dest='log_file', help=I18n.get('--output_file'))
 
     return parser.parse_args()
 
@@ -111,7 +111,8 @@ def main():
     # Setup file handler
     # Remove ANSI codes, log all levels
     # Add date to  file logs
-    file_formatter = logging.Formatter('[%(asctime)s]%(nocolor)s', '%Y-%m-%d')
+    file_formatter = logging.Formatter('[%(asctime)s] %(nocolor)s',
+                                       '%Y-%m-%d %H:%M:%S')
     file_filter = FileFilter()
     logfile = os.path.join(os.getcwd(), "log", args.log_file)
     # 5 rotating log files, max 8mb each for discord compatability
@@ -125,7 +126,9 @@ def main():
     # Setup stdout handler
     # Don't print DEBUG or WARNING messages unless verbose flag is set
     # Clear line first to prevent issues with the timer
-    stream_formatter = logging.Formatter(80 * ' ' + '\r' + '%(message)s')
+    stream_formatter = logging.Formatter(80 * ' ' + '\r'
+                                         + '[%(asctime)s] %(message)s',
+                                         '%H:%M:%S')
     streamhandler = logging.StreamHandler(sys.stdout)
     if False:  # TODO: verbose flag
         streamhandler.setLevel(logging.DEBUG)

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from src.i18n import I18n
 from src.image import Image
 
 logger = logging.getLogger('bot')
+bar_print = logging.getLogger('loading_bar')
 
 
 class FileFilter(logging.Filter):
@@ -143,6 +144,13 @@ def main():
     logger.addHandler(filehandler)
     logger.addHandler(streamhandler)
     logger.setLevel(logging.DEBUG)
+
+    # Setup bar logger, to avoid threading issues with print
+    bar_stream = logging.StreamHandler(sys.stdout)
+    bar_stream.flush = sys.stdout.flush
+    bar_stream.terminator = "\r"
+    bar_print.addHandler(bar_stream)
+    bar_print.setLevel(logging.INFO)
 
     image = Image(args.file, args.round_sensitive, args.image_brightness)
 

--- a/main.py
+++ b/main.py
@@ -115,8 +115,8 @@ def main():
     # Setup file handler
     # Remove ANSI codes, log all levels
     # Add date to  file logs
-    file_formatter = logging.Formatter('[%(asctime)s] %(nocolor)s',
-                                       '%Y-%m-%d %H:%M:%S')
+    file_formatter = logging.Formatter('%(asctime)s %(nocolor)s',
+                                       '%Y-%m-%d:%H:%M:%S%z')
     file_filter = FileFilter()
     logfile = os.path.join(os.getcwd(), "log", args.log_file)
     # 5 rotating log files, max 8mb each for discord compatability

--- a/main.py
+++ b/main.py
@@ -133,6 +133,7 @@ def main():
                                          + '[%(asctime)s] %(message)s',
                                          '%H:%M:%S')
     streamhandler = logging.StreamHandler(sys.stdout)
+    streamhandler.flush = sys.stdout.flush
     if args.verbose:
         streamhandler.setLevel(logging.DEBUG)
     else:

--- a/main.py
+++ b/main.py
@@ -115,8 +115,8 @@ def main():
     # Setup file handler
     # Remove ANSI codes, log all levels
     # Add date to  file logs
-    file_formatter = logging.Formatter('%(asctime)s %(nocolor)s',
-                                       '%Y-%m-%d:%H:%M:%S%z')
+    file_formatter = logging.Formatter('[%(asctime)s] %(nocolor)s',
+                                       '%Y-%m-%d %H:%M:%S%z')
     file_filter = FileFilter()
     logfile = os.path.join(os.getcwd(), "log", args.log_file)
     # 5 rotating log files, max 8mb each for discord compatability

--- a/src/bot.py
+++ b/src/bot.py
@@ -84,14 +84,14 @@ class Bot(object):
         end = time.time()
         self.paint_lag = end - start
         while not response['success']:
-            logger.debug(I18n.get('error.try_again'))
+            logger.error(I18n.get('error.try_again'))
             self.wait_time(response)
             # Redeclare intent after a timer
             self.pixel_intent = (x, y, color.index)
             response = self.pixelio.send_pixel(x, y, color)
 
         self.canvas.update(x, y, color)
-        logger.debug(I18n.get('paint.user', color=Fore.CYAN).format(
+        logger.info(I18n.get('paint.user', color=Fore.CYAN).format(
             color=I18n.get(str(color.name), inline=True, end=None), x=x, y=y))
         return self.wait_time(response)
 
@@ -112,7 +112,7 @@ class Bot(object):
             # no delta if wait error
             if 'errors' in data and {'msg': 'You must wait'} in data['errors']:
                 wait = data['waitSeconds']
-                logger.debug(I18n.get('error.cooldown'))
+                logger.error(I18n.get('error.cooldown'))
             # apply delta
             else:
                 mod_time = data['waitSeconds'] + self.get_delta()
@@ -121,11 +121,11 @@ class Bot(object):
             formattedWait = str(datetime.timedelta(seconds=int(wait)))
             formattedWait = formattedWait[2:]
             if wait > 60:
-                logger.debug(I18n.get('paint.waitmin')
-                             .format(time=formattedWait))
+                logger.info(I18n.get('paint.waitmin')
+                            .format(time=formattedWait))
             else:
-                logger.debug(I18n.get('paint.waitsec')
-                             .format(time=formattedWait))
+                logger.info(I18n.get('paint.waitsec')
+                            .format(time=formattedWait))
 
             # initial bar
             print_progress_bar(0, wait, prefix='', suffix='Seconds',
@@ -188,6 +188,7 @@ class Bot(object):
         canvas = Matrix(num_blocks, center_block_x, center_block_y)
 
         threads = []
+        logger.info(I18n.get('chunk.begin_load'))
         for center_x in range(center_block_x - num_blocks,
                               1 + center_block_x + num_blocks, 15):
             for center_y in range(center_block_y - num_blocks,

--- a/src/bot.py
+++ b/src/bot.py
@@ -92,7 +92,7 @@ class Bot(object):
 
         self.canvas.update(x, y, color)
         logger.info(I18n.get('paint.user', color=Fore.CYAN).format(
-            color=I18n.get(str(color.name), inline=True, end=None), x=x, y=y))
+            color=I18n.get(str(color.name), end=None), x=x, y=y))
         return self.wait_time(response)
 
     def wait_time(self, data={'waitSeconds': None}):

--- a/src/bot.py
+++ b/src/bot.py
@@ -15,6 +15,7 @@ from .pixelcanvasio import PixelCanvasIO
 from .strategy import FactoryStrategy, Status
 
 logger = logging.getLogger('bot')
+bar_print = logging.getLogger('loading_bar')
 
 
 class Bot(object):
@@ -104,9 +105,9 @@ class Bot(object):
                                length=100, fill='█'):
             filled_length = int(length * iteration / total)
             bar = fill * filled_length + '-' * (length - filled_length)
-            print('%s|%s| %.2f %s'
-                  % (prefix, bar, round(total - iteration, 2), suffix)
-                  + (4 * ' '), end='\r', flush=True)
+            bar_print.info('%s|%s| %.2f %s'
+                           % (prefix, bar, round(total - iteration, 2), suffix)
+                           + (4 * ' '))
 
         if data['waitSeconds'] is not None and data['waitSeconds'] > 0:
             # no delta if wait error

--- a/src/colors.py
+++ b/src/colors.py
@@ -97,7 +97,7 @@ class EnumColor:
 
         # return rounding colour
 
-        name = I18n.get(str(EnumColor.rgba(diff_min[0]).name), True)
+        name = I18n.get(str(EnumColor.rgba(diff_min[0]).name))
         if not silent:
             logger.debug(I18n.get('colors.round').format(
                 rgba=rgba, diff_min=diff_min[0], name=name))

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -8,7 +8,7 @@ init()
 
 class I18n(object):
     @staticmethod
-    def get(key, inline=False, color=None, end=Style.RESET_ALL):
+    def get(key, color=None, end=Style.RESET_ALL):
         prefix = color if color else ""
         suffix = end if end and color else ""
 
@@ -22,10 +22,7 @@ class I18n(object):
                 # If it doesn't exist whatsoever
                 raise original_exception
 
-        if inline:
-            return prefix + value + suffix
-        else:
-            return prefix + '[' + time.strftime("%H:%M:%S") + '] ' + value + suffix
+        return prefix + value + suffix
 
     _all = {
         'en_GB': {

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -34,6 +34,7 @@ class I18n(object):
             'chunk.blind.east': 'This bot may be blind for all pixels east of {x}.',
             'chunk.blind.south': 'This bot may be blind for all pixels south of {y}.',
             'chunk.load': 'Loading chunk ({x}, {y})...',
+            'chunk.begin_load': 'Loading canvas...',
 
             'error.try_again': 'Oh no, an error occurred. Trying again.',
             'error.proxy': 'Oh no, you are using a proxy.',
@@ -120,6 +121,7 @@ class I18n(object):
             'chunk.blind.east': 'Il se pourrait que ce bot ne puisse pas voir à l\'est de {x}.',
             'chunk.blind.south': 'Il se pourrait que ce bot ne puisse pas voir au sud de {y}.',
             'chunk.load': 'Je charge chunk ({x}, {y})...',
+            'chunk.begin_load': 'Chargement...',
 
             'error.try_again': 'Oh la! Une erreur est survenue. J\'essaie encore de le faire.',
             'error.proxy': 'Oh la! Tu utilises un proxy.',
@@ -205,6 +207,7 @@ class I18n(object):
             'chunk.blind.east': 'Esse bot pode não ler pixels ao leste de {x}',
             'chunk.blind.south': 'Esse bot pode não ler pixels ao sul de {y}',
             'chunk.load': 'Carregando chunk ({x}, {y})...',
+            'chunk.begin_load': 'Carregando...',
 
             'error.try_again': 'Ocorreu um erro. Tentando novamente.',
             'error.proxy': 'Ops! Parece que você esta usando um Proxy',

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -92,6 +92,8 @@ class I18n(object):
             '--notify': 'Send a system notification if a captcha is encountered by the bot. Notification remains for 30 seconds or until dismissed.',
             '--output_file': 'Output the logs to this file. (default: logfile.log).',
             '--locale': 'The language to use. Choose from [{languages}].',
+            '--verbose': 'Show debugging prints in the terminal. '
+                         'By default they are sent only to the log file.',
 
             # Colors
             'white': 'white',
@@ -178,6 +180,9 @@ class I18n(object):
             '--notify': 'Envoyer-toi un notification quand le bot a besoin d\'une nouvelle zone de texte.',
             '--output_file': 'Écrire le journal d\'événements dans ce fichier.',
             '--locale': 'La langue à utiliser. Choisir parmi [{languages}].',
+            '--verbose': 'Show debugging prints in the terminal. '
+                         'By default they are sent only to the log file. '
+                         '[NEEDS TRANSLATION]',
 
             # Colors
             'white': 'blanc',
@@ -265,6 +270,9 @@ class I18n(object):
             '--notify': 'Enviar uma notificação de sistema quando o bot detecta um Captcha. A notificação dura 30 segundos, ou até ser removida.',
             '--output_file': 'Arquivo de logs. (Por padrão: logfile.log)',
             '--locale': 'Língua a usar. Escolha entre [{languages}].',
+            '--verbose': 'Show debugging prints in the terminal. '
+                         'By default they are sent only to the log file. '
+                         '[NEEDS TRANSLATION]',
 
             # Colors
             'white': 'branco',

--- a/src/image.py
+++ b/src/image.py
@@ -25,16 +25,16 @@ class Image(object):
         tmb_full_path = os.getcwd() + '/img/.cache/' + self.checksum + '.png'
 
         if (os.path.isfile(tmb_full_path)):
-            logger.debug(I18n.get('external.load_cache'))
+            logger.info(I18n.get('external.load_cache'))
             return pillow.open(tmb_full_path).convert('RGBA')
 
-        logger.debug(I18n.get('external.generating').format(
+        logger.info(I18n.get('external.generating').format(
             path=tmb_full_path))
 
         new_image = self.convert_pixels(pillow.open(file).convert('RGBA'))
         self.save_image(new_image, tmb_full_path)
 
-        logger.debug(I18n.get('external.saved_cache'))
+        logger.info(I18n.get('external.saved_cache'))
         return pillow.open(tmb_full_path).convert('RGBA')
 
     def md5(self, fname):
@@ -85,5 +85,5 @@ class Image(object):
         url = pyqrcode.create(text)
         url.png(full_QR_path, scale)
 
-        logger.debug(I18n.get('qr_created').format(path=full_QR_path))
-        logger.debug(url.text())
+        logger.info(I18n.get('qr_created').format(path=full_QR_path))
+        logger.info(url.text())

--- a/src/pixelcanvasio.py
+++ b/src/pixelcanvasio.py
@@ -163,8 +163,7 @@ class PixelCanvasIO(object):
                         template_color = EnumColor.rgba(
                             self.bot.image.pix[x - self.bot.start_x,
                                                y - self.bot.start_y])
-                        color_name = I18n.get(color.name, inline=True,
-                                              end=None)
+                        color_name = I18n.get(color.name, end=None)
                         if (template_color in self.bot.colors_ignored
                                 or template_color.rgba[3] == 0):
                             logger.info(

--- a/src/pixelcanvasio.py
+++ b/src/pixelcanvasio.py
@@ -86,7 +86,7 @@ class PixelCanvasIO(object):
         try:
             response = self.post(PixelCanvasIO.URL + "api/pixel", payload)
         except requests.exceptions.ConnectionError:
-            logger.debug(I18n.get('error.connection'))
+            logger.error(I18n.get('error.connection'))
             return self.pxrate.update({'success': 0, 'waitSeconds': 5})
 
         if response.status_code == 403:
@@ -167,15 +167,15 @@ class PixelCanvasIO(object):
                                               end=None)
                         if (template_color in self.bot.colors_ignored
                                 or template_color.rgba[3] == 0):
-                            logger.debug(
+                            logger.info(
                                 I18n.get('paint.outside', color=Fore.YELLOW)
                                 .format(x=x, y=y, color=color_name))
                         elif color == template_color:
-                            logger.debug(
+                            logger.info(
                                 I18n.get('paint.ally', color=Fore.GREEN)
                                 .format(x=x, y=y, color=color_name))
                         else:
-                            logger.debug(
+                            logger.info(
                                 I18n.get('paint.enemy', color=Fore.RED)
                                 .format(x=x, y=y, color=color_name))
                     elif (x, y, color.index) == self.bot.pixel_intent:
@@ -189,11 +189,11 @@ class PixelCanvasIO(object):
             ws.close()
 
         def on_close(ws):
-            logger.debug(I18n.get('websocket.closed'))
+            logger.warning(I18n.get('websocket.closed'))
             open_connection()
 
         def on_open(ws):
-            logger.debug(I18n.get("websocket.opened"))
+            logger.info(I18n.get("websocket.opened"))
 
         def open_connection():
             url = self.get_ws()

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -130,7 +130,7 @@ class Sketch(Strategy):
 
     def apply(self):
         if self.priorities == []:
-            print(I18n.get('strategy.left_right_top_bottom'))
+            logger.debug(I18n.get('strategy.left_right_top_bottom'))
             near_color = 0
 
             for y in range(self.bot.image.height):
@@ -142,7 +142,7 @@ class Sketch(Strategy):
                     near_color = color
                 near_color = 0
 
-            print(I18n.get('strategy.right_left_top_bottom'))
+            logger.debug(I18n.get('strategy.right_left_top_bottom'))
 
             near_color = 0
 
@@ -155,7 +155,7 @@ class Sketch(Strategy):
                     near_color = color
                 near_color = 0
 
-            print(I18n.get('strategy.top_bottom_left_right'))
+            logger.debug(I18n.get('strategy.top_bottom_left_right'))
 
             near_color = 0
 
@@ -168,7 +168,7 @@ class Sketch(Strategy):
                     near_color = color
                 near_color = 0
 
-            print(I18n.get('strategy.bottom_top_left_right'))
+            logger.debug(I18n.get('strategy.bottom_top_left_right'))
 
             near_color = 0
 
@@ -214,7 +214,7 @@ class Status(Strategy):
         incorrect_px = px_active_total - correct_px
         progress = round(float(correct_px) / px_active_total * 100., 2)
 
-        logger.debug(I18n.get('progress').format(total=px_active_total, correct=correct_px, incorrect=incorrect_px, progress=progress))
+        logger.info(I18n.get('progress').format(total=px_active_total, correct=correct_px, incorrect=incorrect_px, progress=progress))
         return progress
 
 
@@ -407,7 +407,8 @@ class FactoryStrategy(object):
                            colors_ignored, colors_not_overwrite, prioritized,
                            px=px, py=py)
 
-        print(I18n.get('strategy.auto_select').format(strategy=strategy))
+        logger.warning(I18n.get('strategy.auto_select')
+                       .format(strategy=strategy))
 
         return Spiral(bot.canvas, bot.image, bot.start_x, bot.start_y,
                     colors_ignored, colors_not_overwrite, prioritized,


### PR DESCRIPTION
Addresses issues #56, #74, and #75.

Key changes:
- The terminal log and the file log now use different logging levels, unless a `--verbose` flag is given.
- Moved time-stamping duties from i18n to the respective loggers.
- The log file now uses database style timestamps for searchability
- ANSI codes are filtered from the file logs
- The timer now uses its own logger, to solve the issues with `print()` and threads.

Error logging is still an issue; it's very inconsistent throughout our code. I think it would be better to make that a separate project, ideally using `logging.exception()` or the `exc_info=True` parameter, to send stack traces to the log file.